### PR TITLE
Implement/353/channel page query

### DIFF
--- a/src/modules/item/items/dtos/item.filter.ts
+++ b/src/modules/item/items/dtos/item.filter.ts
@@ -53,3 +53,12 @@ export class ItemFilter implements Partial<IItem> {
   @Field(() => String, { nullable: true })
   orderBy?: keyof IItem;
 }
+
+@InputType()
+export class ReviewItemFilter {
+  @Field(() => Int)
+  reviewerId: number;
+
+  @Field(() => Boolean, { nullable: true })
+  orderByDigestRating?: boolean;
+}

--- a/src/modules/item/items/entities/item.entity.ts
+++ b/src/modules/item/items/entities/item.entity.ts
@@ -191,6 +191,8 @@ export class ItemEntity extends BaseIdEntity implements IItem {
   @Column({ type: 'float', default: 0 })
   score: number;
 
+  @Field(() => Int, { nullable: true, description: '[MODEL ONLY]' })
+  maxDigestRating: number;
   @Field({ description: '[MODEL ONLY]' })
   get originalPrice(): number {
     return this.prices.find(({ isActive }) => isActive === true).originalPrice;

--- a/src/modules/item/items/helpers/index.ts
+++ b/src/modules/item/items/helpers/index.ts
@@ -1,2 +1,3 @@
-export * from './item.helper';
 export * from './item-detail-image.helper';
+export * from './item-query.helper';
+export * from './item.helper';

--- a/src/modules/item/items/helpers/item-query.helper.ts
+++ b/src/modules/item/items/helpers/item-query.helper.ts
@@ -1,0 +1,32 @@
+import { SelectQueryBuilder } from 'typeorm';
+
+import { ReviewItemFilter } from '../dtos';
+import { ItemEntity } from '../entities';
+
+export const reviewedItemsQuery = (
+  queryBuilder: SelectQueryBuilder<ItemEntity>,
+  filter: ReviewItemFilter
+) => {
+  const { orderByDigestRating, reviewerId } = filter;
+  const chunks = ['item.score > 0'];
+  reviewerId && chunks.push(`digest.userId = ${reviewerId}`);
+  orderByDigestRating && chunks.push(`digest.rating IS NOT NULL`);
+
+  queryBuilder
+    .leftJoinAndSelect('item.prices', 'price')
+    .leftJoinAndSelect('item.brand', 'brand')
+    .innerJoin('digest', 'digest', 'digest.itemId = item.id')
+    .where(chunks.join(' AND '))
+    .groupBy('item.id')
+    .addGroupBy('price.id')
+    .orderBy('item.score', 'DESC');
+
+  if (orderByDigestRating) {
+    queryBuilder
+      .addSelect('MAX(digest.rating)', 'maxDigestRating')
+      .orderBy('maxDigestRating', 'DESC')
+      .addOrderBy('item.score', 'DESC');
+  }
+
+  return queryBuilder;
+};

--- a/src/modules/item/items/items.repository.ts
+++ b/src/modules/item/items/items.repository.ts
@@ -5,6 +5,7 @@ import { BaseRepository } from '@common/base.repository';
 import { ImageRepository } from '@common/image.repository';
 import { removeProtocolFrom } from '@common/helpers';
 
+import { ReviewItemFilter } from './dtos';
 import {
   ItemEntity,
   ItemSizeChartEntity,
@@ -13,6 +14,7 @@ import {
   ItemDetailImageEntity,
   ItemPriceEntity,
 } from './entities';
+import { reviewedItemsQuery } from './helpers';
 import {
   Item,
   ItemSizeChart,
@@ -60,6 +62,22 @@ export class ItemsRepository extends BaseRepository<ItemEntity, Item> {
       .getOne();
 
     return item?.id;
+  }
+
+  async findReviewItems(filter: ReviewItemFilter) {
+    const qb = reviewedItemsQuery(this.createQueryBuilder('item'), filter);
+
+    const itemEntities = await qb.getMany();
+    if (filter.orderByDigestRating) {
+      const raws = await qb.getRawMany();
+      itemEntities.forEach((item) => {
+        item.maxDigestRating = raws.find(
+          (raw) => raw.item_id === item.id
+        ).maxDigestRating;
+      });
+    }
+
+    return itemEntities;
   }
 }
 

--- a/src/modules/item/items/items.resolver.ts
+++ b/src/modules/item/items/items.resolver.ts
@@ -18,6 +18,7 @@ import { ItemRelationType, ITEM_RELATIONS } from './constants';
 import {
   ItemFilter,
   ManualCreateItemInput,
+  ReviewItemFilter,
   SetCategoryToItemInput,
 } from './dtos';
 import { Item } from './models';
@@ -187,5 +188,13 @@ export class ItemsResolver extends BaseResolver<ItemRelationType> {
     @Args('itemFilter', { nullable: true }) itemFilter?: ItemFilter
   ): Promise<number> {
     return await this.itemsService.count(itemFilter);
+  }
+
+  @Query(() => [Item])
+  async reviewItems(
+    @Args('reviewItemFilter', { nullable: true })
+    reviewItemFilter: ReviewItemFilter
+  ): Promise<Item[]> {
+    return await this.itemsService.findReviewItems(reviewItemFilter);
   }
 }

--- a/src/modules/item/items/items.service.ts
+++ b/src/modules/item/items/items.service.ts
@@ -25,6 +25,7 @@ import {
   ManualCreateItemInput,
   CreateItemSizeChartInput,
   UpdateItemSizeChartInput,
+  ReviewItemFilter,
 } from './dtos';
 import { InvalidItemUrlException } from './exceptions';
 import { ItemFactory } from './factories';
@@ -250,8 +251,11 @@ export class ItemsService {
       throw new InvalidItemUrlException();
     }
 
-    const { name, salePrice, originalPrice } =
-      await this.crawlerService.crawlInfo(item.url);
+    const {
+      name,
+      salePrice,
+      originalPrice,
+    } = await this.crawlerService.crawlInfo(item.url);
     await this.update(item.id, { name });
 
     if (item.sellPrice === salePrice && item.originalPrice === originalPrice) {
@@ -404,5 +408,11 @@ export class ItemsService {
     item.sizeChart = null;
     await this.itemsRepository.save(item);
     await this.itemSizeChartsRepository.remove(sizeChart);
+  }
+
+  async findReviewItems(filter: ReviewItemFilter) {
+    return this.itemsRepository.entityToModelMany(
+      await this.itemsRepository.findReviewItems(filter)
+    );
   }
 }

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -989,6 +989,9 @@ type Item {
   isSoldout: Boolean!
   majorCategory: ItemCategory
   majorCategoryId: Float
+
+  """[MODEL ONLY]"""
+  maxDigestRating: Int
   minorCategory: ItemCategory
   minorCategoryId: Float
   name: String!
@@ -2263,6 +2266,7 @@ type Query {
   """refresh token을 받아서 새로운 JwtToken을 생성합니다."""
   refreshJwtToken: JwtToken!
   requestPin(requestPinInput: RequestPinInput!): Boolean!
+  reviewItems(reviewItemFilter: ReviewItemFilter): [Item!]!
   rootExchangeRequests(exchangeRequestFilter: ExchangeRequestFilter, pageInput: PageInput): [ExchangeRequest!]!
   rootInquiries(filter: InquiryFilter, pageInput: PageInput): [Inquiry!]!
 
@@ -2461,6 +2465,11 @@ input RequestPinInput {
 input ReshipExchangeRequestInput {
   courierId: Int!
   trackCode: String!
+}
+
+input ReviewItemFilter {
+  orderByDigestRating: Boolean
+  reviewerId: Int!
 }
 
 type SearchExchangeRequestsOutput {


### PR DESCRIPTION
## Description
체널 페이지에서 필요한 쿼리를 추가하였습니다.
홈의 리뷰어 PICKK 베스트 상품과 추천템 쿼리를 구현하였습니다.

**ReviewItemFilter**
reviewerId와 orderByDigestRating을 컬럼으로 가집니다.

**Query**
reviewItems(ReviewItemFilter)
itemsService의findReviewItems 를 호출합니다.

**Service**
findReviewItems(ReviewItemFilter)
itemsRepository의findReviewItems 를 호출합니다.

**Repository**
findReviewItems(ReviewItemFilter)
reviewItemsQuery 헬퍼를 이용하여 디비를 조회합니다.

**ItemEntity**
maxDigestRating model only 필드를 추가하였습니다.
상품의 꿀템픽들 중 최대 점수로 정렬을 하기위해 추가되었습니다.

**query helper**
reviewItemsQuery(queryBuilder, ReviewItemFilter)
reviewerId로 필터링한후, item의 score로 내림차순 정렬합니다.
orderByDigestRating이 true인 경우, maxDigestRating을 쿼리하고, 해당 결과를 내림차순 정렬합니다.



## Related Issues

resolve #355
fix #


## Checklist

PR을 생성하기 전에 아래에서 만족한 요구사항들의 박스를 체크해주세요. (`[x]`) 원활하고 빠른 리뷰 프로세스를 위해 필요한 과정입니다.

- [x] 모든 **변경점**들을 확인했으며 적절히 알렸습니다.
- [x] Run `npm run test` or `npm run test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
